### PR TITLE
index.html: Fix incorrect Enyo framework location

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<title>SynerIRC</title>
-	<script src="C:\Program Files (x86)\HP webOS\SDK\share\framework\enyo/1.0/framework/enyo.js" type="text/javascript"></script>
+	<script src="/usr/palm/frameworks/enyo/1.0/framework/enyo.js" type="text/javascript"></script>
 </head>
 <body>
 <script type="text/javascript">


### PR DESCRIPTION
Signed-off-by: Herman van Hazendonk <github.com@herrie.org>